### PR TITLE
[Work3]  상품 주문/주문 이력 조회/주문 취소 기능 구현

### DIFF
--- a/src/main/java/com/shop/projectlion/domain/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/com/shop/projectlion/domain/delivery/repository/DeliveryRepository.java
@@ -11,5 +11,5 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     List<Delivery> findByMember(Member member);
 
 //    Optional<List<Delivery>> findByMember(Member member);
-
+//    Delivery findByItem(Item item);
 }

--- a/src/main/java/com/shop/projectlion/domain/delivery/service/DeliveryService.java
+++ b/src/main/java/com/shop/projectlion/domain/delivery/service/DeliveryService.java
@@ -28,5 +28,9 @@ public class DeliveryService {
         return deliveryRepository.findByMember(member);
     }
 
+//    public Delivery findByItem(Item item){
+//        return deliveryRepository.findByItem(item);
+//    }
+
 
 }

--- a/src/main/java/com/shop/projectlion/domain/item/entity/Item.java
+++ b/src/main/java/com/shop/projectlion/domain/item/entity/Item.java
@@ -90,10 +90,6 @@ public class Item extends BaseEntity {
         this.delivery = delivery;
     }
 
-//    public void removeStock(Integer stockNumber){
-//        this.stockNumber -= stockNumber;
-//    }
-
     public void decreaseStock(Integer stockNumber){
         int restStock = this.stockNumber - stockNumber;
         if(restStock < 0) {
@@ -103,6 +99,10 @@ public class Item extends BaseEntity {
         if(this.stockNumber == 0) {
             this.itemSellStatus = ItemSellStatus.SOLD_OUT;
         }
+    }
+
+    public void increaseStock(int stockNumber){
+        this.stockNumber += stockNumber;
     }
 
 }

--- a/src/main/java/com/shop/projectlion/domain/item/entity/Item.java
+++ b/src/main/java/com/shop/projectlion/domain/item/entity/Item.java
@@ -88,4 +88,9 @@ public class Item extends BaseEntity {
         this.delivery = delivery;
     }
 
+    public Item removeStock(Integer stockNumber){
+        this.stockNumber -= stockNumber;
+        return null;
+    }
+
 }

--- a/src/main/java/com/shop/projectlion/domain/item/entity/Item.java
+++ b/src/main/java/com/shop/projectlion/domain/item/entity/Item.java
@@ -4,6 +4,8 @@ import com.shop.projectlion.domain.base.BaseEntity;
 import com.shop.projectlion.domain.delivery.entity.Delivery;
 import com.shop.projectlion.domain.item.constant.ItemSellStatus;
 import com.shop.projectlion.domain.member.entity.Member;
+import com.shop.projectlion.global.error.exception.ErrorCode;
+import com.shop.projectlion.global.error.exception.OutofStockException;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -88,9 +90,19 @@ public class Item extends BaseEntity {
         this.delivery = delivery;
     }
 
-    public Item removeStock(Integer stockNumber){
-        this.stockNumber -= stockNumber;
-        return null;
+//    public void removeStock(Integer stockNumber){
+//        this.stockNumber -= stockNumber;
+//    }
+
+    public void decreaseStock(Integer stockNumber){
+        int restStock = this.stockNumber - stockNumber;
+        if(restStock < 0) {
+            throw new OutofStockException(ErrorCode.NOT_EXISTS_STOCK.getMessage() + " (현재 재고 수량: " + this.stockNumber + ")");
+        }
+        this.stockNumber = restStock;
+        if(this.stockNumber == 0) {
+            this.itemSellStatus = ItemSellStatus.SOLD_OUT;
+        }
     }
 
 }

--- a/src/main/java/com/shop/projectlion/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/shop/projectlion/domain/item/repository/ItemRepository.java
@@ -9,9 +9,9 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
 
-    @Query("select t " +
-            "from Item t " +
-            "where (t.itemName like %:searchQuery% or t.itemDetail like %:searchQuery%) and t.itemSellStatus = :status ")
+    @Query("select i " +
+            "from Item i " +
+            "where (i.itemName like %:searchQuery% or i.itemDetail like %:searchQuery%) and i.itemSellStatus = :status ")
     Page<Item> getMainItemsPage(String searchQuery, ItemSellStatus status, Pageable pageable);
 
 }

--- a/src/main/java/com/shop/projectlion/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/shop/projectlion/domain/item/repository/ItemRepository.java
@@ -1,8 +1,17 @@
 package com.shop.projectlion.domain.item.repository;
 
+import com.shop.projectlion.domain.item.constant.ItemSellStatus;
 import com.shop.projectlion.domain.item.entity.Item;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
+
+    @Query("select t " +
+            "from Item t " +
+            "where (t.itemName like %:searchQuery% or t.itemDetail like %:searchQuery%) and t.itemSellStatus = :status ")
+    Page<Item> getMainItemsPage(String searchQuery, ItemSellStatus status, Pageable pageable);
 
 }

--- a/src/main/java/com/shop/projectlion/domain/item/service/ItemService.java
+++ b/src/main/java/com/shop/projectlion/domain/item/service/ItemService.java
@@ -5,6 +5,7 @@ import com.shop.projectlion.domain.item.entity.Item;
 import com.shop.projectlion.domain.item.repository.ItemRepository;
 import com.shop.projectlion.global.error.exception.EntityNotFoundException;
 import com.shop.projectlion.global.error.exception.ErrorCode;
+import com.shop.projectlion.global.error.exception.OutofStockException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -38,5 +39,14 @@ public class ItemService {
 
     public Page<Item> getMainItems(String searchQurey, Pageable pageable){
         return itemRepository.getMainItemsPage(searchQurey, ItemSellStatus.SELL, pageable);
+    }
+
+    @Transactional
+    public void removeStock(Item item, Integer stockNumber){
+        if(item.getStockNumber() < 0){
+            throw new OutofStockException(ErrorCode.NOT_EXISTS_STOCK);
+        } else {
+            item.removeStock(stockNumber);
+        }
     }
 }

--- a/src/main/java/com/shop/projectlion/domain/item/service/ItemService.java
+++ b/src/main/java/com/shop/projectlion/domain/item/service/ItemService.java
@@ -1,10 +1,13 @@
 package com.shop.projectlion.domain.item.service;
 
+import com.shop.projectlion.domain.item.constant.ItemSellStatus;
 import com.shop.projectlion.domain.item.entity.Item;
 import com.shop.projectlion.domain.item.repository.ItemRepository;
 import com.shop.projectlion.global.error.exception.EntityNotFoundException;
 import com.shop.projectlion.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,5 +34,9 @@ public class ItemService {
         Item savedItem = findByItemId(itemId);
         savedItem.updateItem(updateItem);
         return savedItem;
+    }
+
+    public Page<Item> getMainItems(String searchQurey, Pageable pageable){
+        return itemRepository.getMainItemsPage(searchQurey, ItemSellStatus.SELL, pageable);
     }
 }

--- a/src/main/java/com/shop/projectlion/domain/item/service/ItemService.java
+++ b/src/main/java/com/shop/projectlion/domain/item/service/ItemService.java
@@ -5,7 +5,6 @@ import com.shop.projectlion.domain.item.entity.Item;
 import com.shop.projectlion.domain.item.repository.ItemRepository;
 import com.shop.projectlion.global.error.exception.EntityNotFoundException;
 import com.shop.projectlion.global.error.exception.ErrorCode;
-import com.shop.projectlion.global.error.exception.OutofStockException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -41,12 +40,4 @@ public class ItemService {
         return itemRepository.getMainItemsPage(searchQurey, ItemSellStatus.SELL, pageable);
     }
 
-    @Transactional
-    public void removeStock(Item item, Integer stockNumber){
-        if(item.getStockNumber() < 0){
-            throw new OutofStockException(ErrorCode.NOT_EXISTS_STOCK);
-        } else {
-            item.removeStock(stockNumber);
-        }
-    }
 }

--- a/src/main/java/com/shop/projectlion/domain/itemImage/repository/ItemImageRepository.java
+++ b/src/main/java/com/shop/projectlion/domain/itemImage/repository/ItemImageRepository.java
@@ -12,4 +12,6 @@ public interface ItemImageRepository extends JpaRepository<ItemImage, Long> {
 
     ItemImage findByItemIdAndIsRepImage(Long itemId, Boolean isRepImage);
 
+    List<ItemImage> findByItem(Item item);
+
 }

--- a/src/main/java/com/shop/projectlion/domain/itemImage/repository/ItemImageRepository.java
+++ b/src/main/java/com/shop/projectlion/domain/itemImage/repository/ItemImageRepository.java
@@ -10,4 +10,6 @@ public interface ItemImageRepository extends JpaRepository<ItemImage, Long> {
 
     List<ItemImage> findByItemOrderByIdAsc(Item item);
 
+    ItemImage findByItemIdAndIsRepImage(Long itemId, Boolean isRepImage);
+
 }

--- a/src/main/java/com/shop/projectlion/domain/itemImage/repository/ItemImageRepository.java
+++ b/src/main/java/com/shop/projectlion/domain/itemImage/repository/ItemImageRepository.java
@@ -14,4 +14,7 @@ public interface ItemImageRepository extends JpaRepository<ItemImage, Long> {
 
     List<ItemImage> findByItem(Item item);
 
+    ItemImage findByItemAndIsRepImage(Item item, boolean isRepImage);
+
+
 }

--- a/src/main/java/com/shop/projectlion/domain/itemImage/service/ItemImageService.java
+++ b/src/main/java/com/shop/projectlion/domain/itemImage/service/ItemImageService.java
@@ -88,6 +88,10 @@ public class ItemImageService {
         return itemImageRepository.findByItem(item);
     }
 
+    public ItemImage findByItemAndIsRepImage(Item item, boolean isRepImage) {
+        return itemImageRepository.findByItemAndIsRepImage(item, isRepImage);
+    }
+
 
 
 

--- a/src/main/java/com/shop/projectlion/domain/itemImage/service/ItemImageService.java
+++ b/src/main/java/com/shop/projectlion/domain/itemImage/service/ItemImageService.java
@@ -84,6 +84,10 @@ public class ItemImageService {
         return itemImageRepository.findByItemIdAndIsRepImage(itemId, true);
     }
 
+    public List<ItemImage> getItemDtlImage(Item item){
+        return itemImageRepository.findByItem(item);
+    }
+
 
 
 

--- a/src/main/java/com/shop/projectlion/domain/itemImage/service/ItemImageService.java
+++ b/src/main/java/com/shop/projectlion/domain/itemImage/service/ItemImageService.java
@@ -80,6 +80,10 @@ public class ItemImageService {
         itemImage.initImageInfo();
     }
 
+    public ItemImage getRepImage(Long itemId){
+        return itemImageRepository.findByItemIdAndIsRepImage(itemId, true);
+    }
+
 
 
 

--- a/src/main/java/com/shop/projectlion/domain/order/constant/OrderStatus.java
+++ b/src/main/java/com/shop/projectlion/domain/order/constant/OrderStatus.java
@@ -1,0 +1,5 @@
+package com.shop.projectlion.domain.order.constant;
+
+public enum OrderStatus {
+    ORDER, CANCEL
+}

--- a/src/main/java/com/shop/projectlion/domain/order/entity/Order.java
+++ b/src/main/java/com/shop/projectlion/domain/order/entity/Order.java
@@ -4,6 +4,7 @@ import com.shop.projectlion.domain.base.BaseEntity;
 import com.shop.projectlion.domain.member.entity.Member;
 import com.shop.projectlion.domain.order.constant.OrderStatus;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,6 +33,12 @@ public class Order extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @Builder
+    public Order(OrderStatus orderStatus, LocalDateTime orderTime, Member member){
+        this.orderStatus = orderStatus;
+        this.orderTime = orderTime;
+        this.member = member;
+    }
 
 
 

--- a/src/main/java/com/shop/projectlion/domain/order/entity/Order.java
+++ b/src/main/java/com/shop/projectlion/domain/order/entity/Order.java
@@ -3,6 +3,7 @@ package com.shop.projectlion.domain.order.entity;
 import com.shop.projectlion.domain.base.BaseEntity;
 import com.shop.projectlion.domain.member.entity.Member;
 import com.shop.projectlion.domain.order.constant.OrderStatus;
+import com.shop.projectlion.domain.orderItem.entity.OrderItem;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,6 +40,13 @@ public class Order extends BaseEntity {
         this.orderTime = orderTime;
         this.member = member;
     }
+
+    public void addOrderItem(OrderItem orderItem){
+        orderItem.add(orderItem);
+        orderItem.setOrder(this);
+    }
+
+
 
 
 

--- a/src/main/java/com/shop/projectlion/domain/order/entity/Order.java
+++ b/src/main/java/com/shop/projectlion/domain/order/entity/Order.java
@@ -1,0 +1,40 @@
+package com.shop.projectlion.domain.order.entity;
+
+import com.shop.projectlion.domain.base.BaseEntity;
+import com.shop.projectlion.domain.member.entity.Member;
+import com.shop.projectlion.domain.order.constant.OrderStatus;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "orders")
+public class Order extends BaseEntity {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @Column(name = "order_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OrderStatus orderStatus;
+
+    @Column(nullable = false)
+    private LocalDateTime orderTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+
+
+
+
+
+}

--- a/src/main/java/com/shop/projectlion/domain/order/entity/Order.java
+++ b/src/main/java/com/shop/projectlion/domain/order/entity/Order.java
@@ -11,6 +11,8 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -34,16 +36,30 @@ public class Order extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @OneToMany(mappedBy = "order", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
+    private List<OrderItem> orderItems;
+
     @Builder
-    public Order(OrderStatus orderStatus, LocalDateTime orderTime, Member member){
-        this.orderStatus = orderStatus;
-        this.orderTime = orderTime;
+    public Order(Member member, LocalDateTime orderTime, OrderStatus orderStatus, List<OrderItem> orderItems) {
         this.member = member;
+        this.orderTime = orderTime;
+        this.orderStatus = orderStatus;
+        this.orderItems = orderItems;
     }
 
-    public void addOrderItem(OrderItem orderItem){
-        orderItem.add(orderItem);
-        orderItem.setOrder(this);
+    public static Order createOrder(LocalDateTime orderTime, Member member) {
+        Order order = Order.builder()
+                .member(member)
+                .orderStatus(OrderStatus.ORDER)
+                .orderTime(orderTime)
+                .orderItems(new ArrayList<>())
+                .build();
+        return order;
+    }
+
+    public void addOrderItem(OrderItem orderItem) {
+        orderItems.add(orderItem);
+        orderItem.updateOrder(this);
     }
 
 

--- a/src/main/java/com/shop/projectlion/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/shop/projectlion/domain/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.shop.projectlion.domain.order.repository;
+
+import com.shop.projectlion.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/shop/projectlion/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/shop/projectlion/domain/order/repository/OrderRepository.java
@@ -1,7 +1,29 @@
 package com.shop.projectlion.domain.order.repository;
 
 import com.shop.projectlion.domain.order.entity.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    @Query(value = "select o " +
+            "from Order o join fetch o.member " +
+            "where o.member.email = :email " +
+            "order by o.orderTime desc ",
+            countQuery = "select count(o) " +
+                    "from Order o " +
+                    "where o.member.email = :email")
+    Page<Order> findOrderWithMember(@Param("email") String email, Pageable pageable);
+
+    @Query("select o " +
+            "from Order o join fetch o.member m " +
+            "join fetch o.orderItems oi " +
+            "join fetch oi.item " +
+            "where o.id = :orderId")
+    Optional<Order> findByOrderIdWithMemberAndOrderItemsAndItem(@Param("orderId") Long orderId);
 }

--- a/src/main/java/com/shop/projectlion/domain/order/service/OrderService.java
+++ b/src/main/java/com/shop/projectlion/domain/order/service/OrderService.java
@@ -1,0 +1,12 @@
+package com.shop.projectlion.domain.order.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrderService {
+
+}

--- a/src/main/java/com/shop/projectlion/domain/order/service/OrderService.java
+++ b/src/main/java/com/shop/projectlion/domain/order/service/OrderService.java
@@ -2,7 +2,11 @@ package com.shop.projectlion.domain.order.service;
 
 import com.shop.projectlion.domain.order.entity.Order;
 import com.shop.projectlion.domain.order.repository.OrderRepository;
+import com.shop.projectlion.global.error.exception.EntityNotFoundException;
+import com.shop.projectlion.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +20,15 @@ public class OrderService {
     @Transactional
     public void order(Order order) {
         orderRepository.save(order);
+    }
+
+    public Page<Order> findOrderWithMember(String email, Pageable pageable) {
+        return orderRepository.findOrderWithMember(email, pageable);
+    }
+
+    public Order findByOrderIdWithMemberAndOrderItemsAndItem(Long orderId) {
+        return orderRepository.findByOrderIdWithMemberAndOrderItemsAndItem(orderId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ORDER_NOT_EXISTS));
     }
 
 }

--- a/src/main/java/com/shop/projectlion/domain/order/service/OrderService.java
+++ b/src/main/java/com/shop/projectlion/domain/order/service/OrderService.java
@@ -1,5 +1,7 @@
 package com.shop.projectlion.domain.order.service;
 
+import com.shop.projectlion.domain.order.entity.Order;
+import com.shop.projectlion.domain.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,5 +10,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class OrderService {
+
+    private final OrderRepository orderRepository;
+
+    @Transactional
+    public void order(Order order) {
+        orderRepository.save(order);
+    }
 
 }

--- a/src/main/java/com/shop/projectlion/domain/orderItem/entity/OrderItem.java
+++ b/src/main/java/com/shop/projectlion/domain/orderItem/entity/OrderItem.java
@@ -43,11 +43,12 @@ public class OrderItem extends BaseEntity {
         this.order = order;
     }
 
-    public static OrderItem createOrderItem(Item item, OrderItem orderItem){
+    public static OrderItem createOrderItem(Item item, Integer count, Integer orderPrice){
+        item.decreaseStock(count);
         return OrderItem.builder()
-                .count(orderItem.getCount())
-                .orderPrice(orderItem.getOrderPrice())
-                .item(item.removeStock(orderItem.count))
+                .item(item)
+                .count(count)
+                .orderPrice(orderPrice)
                 .build();
     }
 
@@ -56,7 +57,7 @@ public class OrderItem extends BaseEntity {
     }
 
 
-    public void setOrder(Order order) {
+    public void updateOrder(Order order) {
         this.order = order;
     }
 

--- a/src/main/java/com/shop/projectlion/domain/orderItem/entity/OrderItem.java
+++ b/src/main/java/com/shop/projectlion/domain/orderItem/entity/OrderItem.java
@@ -52,7 +52,7 @@ public class OrderItem extends BaseEntity {
                 .build();
     }
 
-    public int getToTalPrice(){
+    public int getTotalPrice(){
         return orderPrice * count;
     }
 
@@ -61,7 +61,7 @@ public class OrderItem extends BaseEntity {
         this.order = order;
     }
 
-    public void add(OrderItem orderItem) {
-
+    public void cancel() {
+        this.getItem().increaseStock(count);
     }
 }

--- a/src/main/java/com/shop/projectlion/domain/orderItem/entity/OrderItem.java
+++ b/src/main/java/com/shop/projectlion/domain/orderItem/entity/OrderItem.java
@@ -43,5 +43,24 @@ public class OrderItem extends BaseEntity {
         this.order = order;
     }
 
+    public static OrderItem createOrderItem(Item item, OrderItem orderItem){
+        return OrderItem.builder()
+                .count(orderItem.getCount())
+                .orderPrice(orderItem.getOrderPrice())
+                .item(item.removeStock(orderItem.count))
+                .build();
+    }
 
+    public int getToTalPrice(){
+        return orderPrice * count;
+    }
+
+
+    public void setOrder(Order order) {
+        this.order = order;
+    }
+
+    public void add(OrderItem orderItem) {
+
+    }
 }

--- a/src/main/java/com/shop/projectlion/domain/orderItem/entity/OrderItem.java
+++ b/src/main/java/com/shop/projectlion/domain/orderItem/entity/OrderItem.java
@@ -1,0 +1,47 @@
+package com.shop.projectlion.domain.orderItem.entity;
+
+import com.shop.projectlion.domain.base.BaseEntity;
+import com.shop.projectlion.domain.item.entity.Item;
+import com.shop.projectlion.domain.order.entity.Order;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "order_item")
+public class OrderItem extends BaseEntity {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @Column(name = "order_item_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private Integer count;
+
+    @Column(nullable = false)
+    private Integer orderPrice;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @Builder
+    public OrderItem(Integer count, Integer orderPrice, Item item, Order order){
+        this.count = count;
+        this.orderPrice = orderPrice;
+        this.item = item;
+        this.order = order;
+    }
+
+
+}

--- a/src/main/java/com/shop/projectlion/domain/orderItem/repository/OrderItemRepository.java
+++ b/src/main/java/com/shop/projectlion/domain/orderItem/repository/OrderItemRepository.java
@@ -1,0 +1,7 @@
+package com.shop.projectlion.domain.orderItem.repository;
+
+import com.shop.projectlion.domain.orderItem.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+}

--- a/src/main/java/com/shop/projectlion/domain/orderItem/service/OrderItemService.java
+++ b/src/main/java/com/shop/projectlion/domain/orderItem/service/OrderItemService.java
@@ -1,0 +1,11 @@
+package com.shop.projectlion.domain.orderItem.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrderItemService {
+}

--- a/src/main/java/com/shop/projectlion/domain/orderItem/service/OrderItemService.java
+++ b/src/main/java/com/shop/projectlion/domain/orderItem/service/OrderItemService.java
@@ -1,5 +1,6 @@
 package com.shop.projectlion.domain.orderItem.service;
 
+import com.shop.projectlion.domain.orderItem.repository.OrderItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,4 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class OrderItemService {
+
+    private final OrderItemRepository orderItemRepository;
+
 }

--- a/src/main/java/com/shop/projectlion/global/config/WebMvcConfig.java
+++ b/src/main/java/com/shop/projectlion/global/config/WebMvcConfig.java
@@ -14,7 +14,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/images/**")   // /images/** url로 요청이 올 경우 uploadPath로부터 파일을 찾음
-                .addResourceLocations("file://" + uploadPath);
+                .addResourceLocations("file:///" + uploadPath);
     }
 
 }

--- a/src/main/java/com/shop/projectlion/global/config/WebMvcConfig.java
+++ b/src/main/java/com/shop/projectlion/global/config/WebMvcConfig.java
@@ -1,0 +1,20 @@
+package com.shop.projectlion.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Value("${file.upload.path}")
+    private String uploadPath;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/images/**")   // /images/** url로 요청이 올 경우 uploadPath로부터 파일을 찾음
+                .addResourceLocations("file://" + uploadPath);
+    }
+
+}

--- a/src/main/java/com/shop/projectlion/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/shop/projectlion/global/config/security/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         ;
 
         http.authorizeRequests()
-                .antMatchers("/", "/login", "/register").permitAll()
+                .antMatchers("/", "/login", "/register", "/images/**").permitAll()
                 .antMatchers("/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated()
         ;

--- a/src/main/java/com/shop/projectlion/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/shop/projectlion/global/config/security/SecurityConfig.java
@@ -35,7 +35,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         ;
 
         http.authorizeRequests()
-                .antMatchers("/", "/login", "/register", "/images/**").permitAll()
+                .antMatchers("/itemdtl/order").authenticated()
+                .antMatchers("/", "/login", "/register", "/images/**", "/itemdtl/**").permitAll()
                 .antMatchers("/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated()
         ;

--- a/src/main/java/com/shop/projectlion/global/error/exception/BusinessException.java
+++ b/src/main/java/com/shop/projectlion/global/error/exception/BusinessException.java
@@ -9,4 +9,8 @@ public class BusinessException extends RuntimeException {
         super(errorCode.getMessage());
     }
 
+    public BusinessException(String errorMessage) {
+        super(errorMessage);
+    }
+
 }

--- a/src/main/java/com/shop/projectlion/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/shop/projectlion/global/error/exception/ErrorCode.java
@@ -16,7 +16,10 @@ public enum ErrorCode {
 
     NOT_EXISTS_FIRST_ITEM_IMAGE(400,"첫번째 상품 이미지는 필수 입력 값 입니다."),
 
-    NOT_EXISTS_STOCK(400,"상품의 재고가 부족 합니다.")
+    NOT_EXISTS_STOCK(400,"상품의 재고가 부족 합니다."),
+
+    ORDER_NOT_EXISTS(400, "해당 주문은 존재하지 않습니다."),
+    NOT_MEMBER_ORDER(403, "해당 회원의 주문이 아닙니다.")
     ;
 
     ErrorCode(int status, String message) {

--- a/src/main/java/com/shop/projectlion/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/shop/projectlion/global/error/exception/ErrorCode.java
@@ -14,7 +14,9 @@ public enum ErrorCode {
     NOT_EXISTS_DELIVERY(400,"배송 정보를 찾을 수 없습니다."),
     NOT_EXISTS_MEMBER(400, "회원 정보를 찾을 수 없습니다."),
 
-    NOT_EXISTS_FIRST_ITEM_IMAGE(400,"첫번째 상품 이미지는 필수 입력 값 입니다.")
+    NOT_EXISTS_FIRST_ITEM_IMAGE(400,"첫번째 상품 이미지는 필수 입력 값 입니다."),
+
+    NOT_EXISTS_STOCK(400,"상품의 재고가 부족 합니다.")
     ;
 
     ErrorCode(int status, String message) {

--- a/src/main/java/com/shop/projectlion/global/error/exception/OutofStockException.java
+++ b/src/main/java/com/shop/projectlion/global/error/exception/OutofStockException.java
@@ -1,8 +1,8 @@
 package com.shop.projectlion.global.error.exception;
 
-public class OutofStockException extends BusinessException {
+public class OutofStockException extends RuntimeException {
 
-    public OutofStockException(ErrorCode errorCode) {
-        super(errorCode);
+    public OutofStockException(String errorMessage) {
+        super(errorMessage);
     }
 }

--- a/src/main/java/com/shop/projectlion/global/error/exception/OutofStockException.java
+++ b/src/main/java/com/shop/projectlion/global/error/exception/OutofStockException.java
@@ -1,0 +1,8 @@
+package com.shop.projectlion.global.error.exception;
+
+public class OutofStockException extends BusinessException {
+
+    public OutofStockException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/shop/projectlion/web/itemdtl/controller/ItemDtlController.java
+++ b/src/main/java/com/shop/projectlion/web/itemdtl/controller/ItemDtlController.java
@@ -2,6 +2,7 @@ package com.shop.projectlion.web.itemdtl.controller;
 
 import com.shop.projectlion.domain.item.constant.ItemSellStatus;
 import com.shop.projectlion.web.itemdtl.dto.ItemDtlDto;
+import com.shop.projectlion.web.itemdtl.service.ItemDtlService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -17,8 +18,13 @@ import java.util.List;
 @RequestMapping("/itemdtl")
 public class ItemDtlController {
 
+    private final ItemDtlService itemDtlService;
+
     @GetMapping(value = "/{itemId}")
     public String itemDtl(Model model, @PathVariable("itemId") Long itemId){
+
+//        ItemDtlDto itemDtlDto = itemDtlService.getItemDtl(itemId);
+
         ItemDtlDto itemDtlDto = ItemDtlDto.builder()
                 .itemId(1L)
                 .itemName("청바지")

--- a/src/main/java/com/shop/projectlion/web/itemdtl/controller/ItemDtlController.java
+++ b/src/main/java/com/shop/projectlion/web/itemdtl/controller/ItemDtlController.java
@@ -1,20 +1,33 @@
 package com.shop.projectlion.web.itemdtl.controller;
 
+import com.shop.projectlion.domain.order.service.OrderService;
+import com.shop.projectlion.global.error.exception.BusinessException;
 import com.shop.projectlion.web.itemdtl.dto.ItemDtlDto;
+import com.shop.projectlion.web.itemdtl.dto.ItemOrderDto;
 import com.shop.projectlion.web.itemdtl.service.ItemDtlService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.security.Principal;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Controller
+@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/itemdtl")
 public class ItemDtlController {
 
     private final ItemDtlService itemDtlService;
+    private final OrderService orderService;
 
     @GetMapping(value = "/{itemId}")
     public String itemDtl(Model model, @PathVariable("itemId") Long itemId){
@@ -23,6 +36,30 @@ public class ItemDtlController {
 
         model.addAttribute("item", itemDtlDto);
         return "itemdtl/itemdtl";
+    }
+
+    @PostMapping("/order")
+    public ResponseEntity<String> order(@RequestBody @Valid ItemOrderDto itemOrderDto
+            , BindingResult bindingResult, Principal principal) {
+
+        if(bindingResult.hasErrors()){
+            StringBuilder sb = new StringBuilder();
+            List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+            for (FieldError fieldError : fieldErrors) {
+                sb.append(fieldError.getDefaultMessage());
+            }
+            return new ResponseEntity<>(sb.toString(), HttpStatus.BAD_REQUEST);
+        }
+
+        try {
+            LocalDateTime orderDateTime = LocalDateTime.now();
+            itemDtlService.order(itemOrderDto, principal.getName(), orderDateTime);
+        } catch (BusinessException e) {
+            log.error(e.getMessage());
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+
+        return ResponseEntity.ok("order success");
     }
 
 }

--- a/src/main/java/com/shop/projectlion/web/itemdtl/controller/ItemDtlController.java
+++ b/src/main/java/com/shop/projectlion/web/itemdtl/controller/ItemDtlController.java
@@ -1,0 +1,40 @@
+package com.shop.projectlion.web.itemdtl.controller;
+
+import com.shop.projectlion.domain.item.constant.ItemSellStatus;
+import com.shop.projectlion.web.itemdtl.dto.ItemDtlDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/itemdtl")
+public class ItemDtlController {
+
+    @GetMapping(value = "/{itemId}")
+    public String itemDtl(Model model, @PathVariable("itemId") Long itemId){
+        ItemDtlDto itemDtlDto = ItemDtlDto.builder()
+                .itemId(1L)
+                .itemName("청바지")
+                .itemDetail("파란색 청바지")
+                .itemSellStatus(ItemSellStatus.SELL)
+                .price(25000)
+                .deliveryFee(3000)
+                .stockNumber(500)
+                .build();
+
+        List<ItemDtlDto.ItemImageDto> itemImageDtos = new ArrayList<>();
+        ItemDtlDto.ItemImageDto itemImageDto = new ItemDtlDto.ItemImageDto("/images/2a87e656-79f0-405f-98da-aee2be5ba333.jpg");
+        itemImageDtos.add(itemImageDto);
+        itemDtlDto.setItemImageDtos(itemImageDtos);
+
+        model.addAttribute("item", itemDtlDto);
+        return "itemdtl/itemdtl";
+    }
+}

--- a/src/main/java/com/shop/projectlion/web/itemdtl/controller/ItemDtlController.java
+++ b/src/main/java/com/shop/projectlion/web/itemdtl/controller/ItemDtlController.java
@@ -1,6 +1,5 @@
 package com.shop.projectlion.web.itemdtl.controller;
 
-import com.shop.projectlion.domain.item.constant.ItemSellStatus;
 import com.shop.projectlion.web.itemdtl.dto.ItemDtlDto;
 import com.shop.projectlion.web.itemdtl.service.ItemDtlService;
 import lombok.RequiredArgsConstructor;
@@ -9,9 +8,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
@@ -23,24 +19,10 @@ public class ItemDtlController {
     @GetMapping(value = "/{itemId}")
     public String itemDtl(Model model, @PathVariable("itemId") Long itemId){
 
-//        ItemDtlDto itemDtlDto = itemDtlService.getItemDtl(itemId);
-
-        ItemDtlDto itemDtlDto = ItemDtlDto.builder()
-                .itemId(1L)
-                .itemName("청바지")
-                .itemDetail("파란색 청바지")
-                .itemSellStatus(ItemSellStatus.SELL)
-                .price(25000)
-                .deliveryFee(3000)
-                .stockNumber(500)
-                .build();
-
-        List<ItemDtlDto.ItemImageDto> itemImageDtos = new ArrayList<>();
-        ItemDtlDto.ItemImageDto itemImageDto = new ItemDtlDto.ItemImageDto("/images/2a87e656-79f0-405f-98da-aee2be5ba333.jpg");
-        itemImageDtos.add(itemImageDto);
-        itemDtlDto.setItemImageDtos(itemImageDtos);
+        ItemDtlDto itemDtlDto = itemDtlService.getItemDtl(itemId);
 
         model.addAttribute("item", itemDtlDto);
         return "itemdtl/itemdtl";
     }
+
 }

--- a/src/main/java/com/shop/projectlion/web/itemdtl/dto/ItemDtlDto.java
+++ b/src/main/java/com/shop/projectlion/web/itemdtl/dto/ItemDtlDto.java
@@ -1,6 +1,8 @@
 package com.shop.projectlion.web.itemdtl.dto;
 
 import com.shop.projectlion.domain.item.constant.ItemSellStatus;
+import com.shop.projectlion.domain.item.entity.Item;
+import com.shop.projectlion.domain.itemImage.entity.ItemImage;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,6 +10,7 @@ import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -30,30 +33,30 @@ public class ItemDtlDto {
 
     private List<ItemImageDto> itemImageDtos = new ArrayList<>();
 
-//    public static ItemDtlDto of(Item item, List<ItemImage> itemImages) {
-//        List<ItemImageDto> itemImageDtos = ItemImageDto.of(itemImages);
-//        ItemDtlDto itemDtlDto = ItemDtlDto.builder()
-//                .itemId(item.getId())
-//                .itemName(item.getItemName())
-//                .price(item.getPrice())
-//                .itemDetail(item.getItemDetail())
-//                .stockNumber(item.getStockNumber())
-//                .itemSellStatus(item.getItemSellStatus())
-//                .deliveryFee(item.getDelivery().getDeliveryFee())
-//                .itemImageDtos(itemImageDtos)
-//                .build();
-//        return itemDtlDto;
-//    }
+    public static ItemDtlDto of(Item item, List<ItemImage> itemImages) {
+        List<ItemImageDto> itemImageDtos = ItemImageDto.of(itemImages);
+        ItemDtlDto itemDtlDto = ItemDtlDto.builder()
+                .itemId(item.getId())
+                .itemName(item.getItemName())
+                .price(item.getPrice())
+                .itemDetail(item.getItemDetail())
+                .stockNumber(item.getStockNumber())
+                .itemSellStatus(item.getItemSellStatus())
+                .deliveryFee(item.getDelivery().getDeliveryFee())
+                .itemImageDtos(itemImageDtos)
+                .build();
+        return itemDtlDto;
+    }
 
     @Getter @Setter
     @Builder @AllArgsConstructor
     public static class ItemImageDto {
         private String imageUrl;
 
-//        public static List<ItemImageDto> of(List<ItemImage> itemImages) {
-//            return itemImages.stream().map(itemImage -> ItemImageDto.builder()
-//                    .imageUrl(itemImage.getImageUrl())
-//                    .build()).collect(Collectors.toList());
-//        }
+        public static List<ItemImageDto> of(List<ItemImage> itemImages) {
+            return itemImages.stream().map(itemImage -> ItemImageDto.builder()
+                    .imageUrl(itemImage.getImageUrl())
+                    .build()).collect(Collectors.toList());
+        }
     }
 }

--- a/src/main/java/com/shop/projectlion/web/itemdtl/dto/ItemDtlDto.java
+++ b/src/main/java/com/shop/projectlion/web/itemdtl/dto/ItemDtlDto.java
@@ -1,0 +1,38 @@
+package com.shop.projectlion.web.itemdtl.dto;
+
+import com.shop.projectlion.domain.item.constant.ItemSellStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class ItemDtlDto {
+
+    private Long itemId;
+
+    private String itemName;
+
+    private Integer price;
+
+    private String itemDetail;
+
+    private Integer stockNumber;
+
+    private ItemSellStatus itemSellStatus;
+
+    private Integer deliveryFee;
+
+    private List<ItemImageDto> itemImageDtos = new ArrayList<>();
+
+    @Getter @Setter
+    @Builder @AllArgsConstructor
+    public static class ItemImageDto {
+        private String imageUrl;
+    }
+}

--- a/src/main/java/com/shop/projectlion/web/itemdtl/dto/ItemDtlDto.java
+++ b/src/main/java/com/shop/projectlion/web/itemdtl/dto/ItemDtlDto.java
@@ -30,9 +30,30 @@ public class ItemDtlDto {
 
     private List<ItemImageDto> itemImageDtos = new ArrayList<>();
 
+//    public static ItemDtlDto of(Item item, List<ItemImage> itemImages) {
+//        List<ItemImageDto> itemImageDtos = ItemImageDto.of(itemImages);
+//        ItemDtlDto itemDtlDto = ItemDtlDto.builder()
+//                .itemId(item.getId())
+//                .itemName(item.getItemName())
+//                .price(item.getPrice())
+//                .itemDetail(item.getItemDetail())
+//                .stockNumber(item.getStockNumber())
+//                .itemSellStatus(item.getItemSellStatus())
+//                .deliveryFee(item.getDelivery().getDeliveryFee())
+//                .itemImageDtos(itemImageDtos)
+//                .build();
+//        return itemDtlDto;
+//    }
+
     @Getter @Setter
     @Builder @AllArgsConstructor
     public static class ItemImageDto {
         private String imageUrl;
+
+//        public static List<ItemImageDto> of(List<ItemImage> itemImages) {
+//            return itemImages.stream().map(itemImage -> ItemImageDto.builder()
+//                    .imageUrl(itemImage.getImageUrl())
+//                    .build()).collect(Collectors.toList());
+//        }
     }
 }

--- a/src/main/java/com/shop/projectlion/web/itemdtl/dto/ItemOrderDto.java
+++ b/src/main/java/com/shop/projectlion/web/itemdtl/dto/ItemOrderDto.java
@@ -1,0 +1,20 @@
+package com.shop.projectlion.web.itemdtl.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+public class ItemOrderDto {
+
+    @NotNull(message = "상품 아이디는 필수 값입니다.")
+    private Long itemId;
+
+    @Min(value = 1, message = "최소 주문 수량은 1개 입니다.")
+    @NotNull(message = "주문 수량은 필수 입력 값입니다.")
+    private Integer count;
+
+}

--- a/src/main/java/com/shop/projectlion/web/itemdtl/service/ItemDtlService.java
+++ b/src/main/java/com/shop/projectlion/web/itemdtl/service/ItemDtlService.java
@@ -1,15 +1,23 @@
 package com.shop.projectlion.web.itemdtl.service;
 
-import com.shop.projectlion.domain.delivery.service.DeliveryService;
 import com.shop.projectlion.domain.item.entity.Item;
 import com.shop.projectlion.domain.item.service.ItemService;
 import com.shop.projectlion.domain.itemImage.entity.ItemImage;
 import com.shop.projectlion.domain.itemImage.service.ItemImageService;
+import com.shop.projectlion.domain.member.entity.Member;
+import com.shop.projectlion.domain.member.service.MemberService;
+import com.shop.projectlion.domain.order.entity.Order;
+import com.shop.projectlion.domain.order.service.OrderService;
+import com.shop.projectlion.domain.orderItem.entity.OrderItem;
+import com.shop.projectlion.global.error.exception.EntityNotFoundException;
+import com.shop.projectlion.global.error.exception.ErrorCode;
 import com.shop.projectlion.web.itemdtl.dto.ItemDtlDto;
+import com.shop.projectlion.web.itemdtl.dto.ItemOrderDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -18,13 +26,34 @@ import java.util.List;
 public class ItemDtlService {
     private final ItemService itemService;
     private final ItemImageService itemImageService;
-    private final DeliveryService deliveryService;
+    private final MemberService memberService;
+    private final OrderService orderService;
 
     public ItemDtlDto getItemDtl(Long itemId){
         Item item = itemService.findByItemId(itemId);
-//        Delivery dtlDelivery = deliveryService.findByItem(item);
         List<ItemImage> itemDtlImage = itemImageService.getItemDtlImage(item);
         return ItemDtlDto.of(item, itemDtlImage);
+    }
+
+    @Transactional
+    public void order(ItemOrderDto itemOrderDto, String email, LocalDateTime orderTime) {
+
+        // 1. 상품 조회
+        Item item = itemService.findByItemId(itemOrderDto.getItemId());
+
+        // 2. 회원 조회
+        Member member = memberService.findMemberByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_EXISTS_MEMBER));
+
+        // 3. 주문 생성
+        Order order = Order.createOrder(orderTime, member);
+
+        // 4. 주문 상품 생성
+        OrderItem orderItem = OrderItem.createOrderItem(item, itemOrderDto.getCount(), item.getPrice());
+        order.addOrderItem(orderItem);
+
+        // 5. 주문 저장
+        orderService.order(order);
     }
 
 

--- a/src/main/java/com/shop/projectlion/web/itemdtl/service/ItemDtlService.java
+++ b/src/main/java/com/shop/projectlion/web/itemdtl/service/ItemDtlService.java
@@ -1,0 +1,21 @@
+package com.shop.projectlion.web.itemdtl.service;
+
+import com.shop.projectlion.domain.delivery.service.DeliveryService;
+import com.shop.projectlion.domain.item.service.ItemService;
+import com.shop.projectlion.domain.itemImage.service.ItemImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ItemDtlService {
+    private final ItemService itemService;
+    private final ItemImageService itemImageService;
+    private final DeliveryService deliveryService;
+
+//    public ItemDtlDto getItemDtl(Long itemId){
+//
+//    }
+}

--- a/src/main/java/com/shop/projectlion/web/itemdtl/service/ItemDtlService.java
+++ b/src/main/java/com/shop/projectlion/web/itemdtl/service/ItemDtlService.java
@@ -1,11 +1,16 @@
 package com.shop.projectlion.web.itemdtl.service;
 
 import com.shop.projectlion.domain.delivery.service.DeliveryService;
+import com.shop.projectlion.domain.item.entity.Item;
 import com.shop.projectlion.domain.item.service.ItemService;
+import com.shop.projectlion.domain.itemImage.entity.ItemImage;
 import com.shop.projectlion.domain.itemImage.service.ItemImageService;
+import com.shop.projectlion.web.itemdtl.dto.ItemDtlDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -15,7 +20,12 @@ public class ItemDtlService {
     private final ItemImageService itemImageService;
     private final DeliveryService deliveryService;
 
-//    public ItemDtlDto getItemDtl(Long itemId){
-//
-//    }
+    public ItemDtlDto getItemDtl(Long itemId){
+        Item item = itemService.findByItemId(itemId);
+//        Delivery dtlDelivery = deliveryService.findByItem(item);
+        List<ItemImage> itemDtlImage = itemImageService.getItemDtlImage(item);
+        return ItemDtlDto.of(item, itemDtlImage);
+    }
+
+
 }

--- a/src/main/java/com/shop/projectlion/web/main/controller/MainController.java
+++ b/src/main/java/com/shop/projectlion/web/main/controller/MainController.java
@@ -1,13 +1,46 @@
 package com.shop.projectlion.web.main.controller;
 
+import com.shop.projectlion.web.main.dto.ItemSearchDto;
+import com.shop.projectlion.web.main.dto.MainItemDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
 @Controller
+@RequiredArgsConstructor
 public class MainController {
 
     @GetMapping("/")
-    public String main() {
+    public String main(ItemSearchDto itemSearchDto, Optional<Integer> page, Model model) {
+
+        Pageable pageable = PageRequest.of(page.isPresent() ? page.get() : 0, 6); // 페이지 및 한 페이지에 나올 페이지 갯수로 pageable 객체 생성
+
+        List<MainItemDto> mainItemDtos = new ArrayList<>();
+        for(int i=0;i<6;i++) {
+            MainItemDto mainItemDto = MainItemDto.builder()
+                    .itemId(Long.valueOf(i))
+                    .itemName("셔츠" + i)
+                    .itemDetail("상품 상세" +i)
+                    .price(3000*(i+1))
+                    .imageUrl("/images/2a87e656-79f0-405f-98da-aee2be5ba333.jpg")
+                    .build();
+            mainItemDtos.add(mainItemDto);
+        }
+        Page<MainItemDto> pageMainItemDto = new PageImpl<>(mainItemDtos, pageable, 30);
+
+        model.addAttribute("items", pageMainItemDto);
+        model.addAttribute("itemSearchDto", itemSearchDto);
+        model.addAttribute("maxPage", 5); // 메인페이지에 노출되는 최대 페이지 갯수
+
         return "main/mainpage";
     }
 

--- a/src/main/java/com/shop/projectlion/web/main/controller/MainController.java
+++ b/src/main/java/com/shop/projectlion/web/main/controller/MainController.java
@@ -2,40 +2,24 @@ package com.shop.projectlion.web.main.controller;
 
 import com.shop.projectlion.web.main.dto.ItemSearchDto;
 import com.shop.projectlion.web.main.dto.MainItemDto;
+import com.shop.projectlion.web.main.service.MainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 @Controller
 @RequiredArgsConstructor
 public class MainController {
 
+    private final MainService mainService;
+
     @GetMapping("/")
     public String main(ItemSearchDto itemSearchDto, Optional<Integer> page, Model model) {
-
-        Pageable pageable = PageRequest.of(page.isPresent() ? page.get() : 0, 6); // 페이지 및 한 페이지에 나올 페이지 갯수로 pageable 객체 생성
-
-        List<MainItemDto> mainItemDtos = new ArrayList<>();
-        for(int i=0;i<6;i++) {
-            MainItemDto mainItemDto = MainItemDto.builder()
-                    .itemId(Long.valueOf(i))
-                    .itemName("셔츠" + i)
-                    .itemDetail("상품 상세" +i)
-                    .price(3000*(i+1))
-                    .imageUrl("/images/2a87e656-79f0-405f-98da-aee2be5ba333.jpg")
-                    .build();
-            mainItemDtos.add(mainItemDto);
-        }
-        Page<MainItemDto> pageMainItemDto = new PageImpl<>(mainItemDtos, pageable, 30);
+        Page<MainItemDto> pageMainItemDto = mainService.getMainItems(itemSearchDto, page);
 
         model.addAttribute("items", pageMainItemDto);
         model.addAttribute("itemSearchDto", itemSearchDto);

--- a/src/main/java/com/shop/projectlion/web/main/dto/ItemSearchDto.java
+++ b/src/main/java/com/shop/projectlion/web/main/dto/ItemSearchDto.java
@@ -1,0 +1,12 @@
+package com.shop.projectlion.web.main.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class ItemSearchDto {
+
+    private String searchQuery = "";
+
+}

--- a/src/main/java/com/shop/projectlion/web/main/dto/MainItemDto.java
+++ b/src/main/java/com/shop/projectlion/web/main/dto/MainItemDto.java
@@ -1,0 +1,22 @@
+package com.shop.projectlion.web.main.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class MainItemDto {
+
+    private Long itemId;
+
+    private String itemName;
+
+    private String itemDetail;
+
+    private String imageUrl;
+
+    private Integer price;
+
+}

--- a/src/main/java/com/shop/projectlion/web/main/dto/MainItemDto.java
+++ b/src/main/java/com/shop/projectlion/web/main/dto/MainItemDto.java
@@ -29,19 +29,5 @@ public class MainItemDto {
         this.price = price;
     }
 
-//    public static Page<MainItemDto> of(Page<Item> items, Page<ItemImage> itemImages ){
-//        return items.stream().map
-//
-//    }
-
-//    public static MainItemDto toDto(Item item, ItemImage itemImage){
-//        return MainItemDto.builder()
-//                .itemId(item.getId())
-//                .itemName(item.getItemName())
-//                .itemDetail(item.getItemDetail())
-//                .imageUrl(itemImage.getImageUrl())
-//                .price(item.getPrice())
-//                .build();
-//    }
 
 }

--- a/src/main/java/com/shop/projectlion/web/main/dto/MainItemDto.java
+++ b/src/main/java/com/shop/projectlion/web/main/dto/MainItemDto.java
@@ -19,4 +19,29 @@ public class MainItemDto {
 
     private Integer price;
 
+    @Builder
+    public MainItemDto(Long itemId, String itemName, String itemDetail,
+                       String imageUrl, Integer price){
+        this.itemId = itemId;
+        this.itemName = itemName;
+        this.itemDetail = itemDetail;
+        this.imageUrl = imageUrl;
+        this.price = price;
+    }
+
+//    public static Page<MainItemDto> of(Page<Item> items, Page<ItemImage> itemImages ){
+//        return items.stream().map
+//
+//    }
+
+//    public static MainItemDto toDto(Item item, ItemImage itemImage){
+//        return MainItemDto.builder()
+//                .itemId(item.getId())
+//                .itemName(item.getItemName())
+//                .itemDetail(item.getItemDetail())
+//                .imageUrl(itemImage.getImageUrl())
+//                .price(item.getPrice())
+//                .build();
+//    }
+
 }

--- a/src/main/java/com/shop/projectlion/web/main/service/MainService.java
+++ b/src/main/java/com/shop/projectlion/web/main/service/MainService.java
@@ -1,0 +1,45 @@
+package com.shop.projectlion.web.main.service;
+
+import com.shop.projectlion.domain.item.entity.Item;
+import com.shop.projectlion.domain.item.service.ItemService;
+import com.shop.projectlion.domain.itemImage.service.ItemImageService;
+import com.shop.projectlion.web.main.dto.ItemSearchDto;
+import com.shop.projectlion.web.main.dto.MainItemDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MainService {
+
+    private final ItemService itemService;
+    private final ItemImageService itemImageService;
+
+    public Page<MainItemDto> getMainItems(ItemSearchDto itemSearchDto, Optional<Integer> page){
+
+        String searchQuery = itemSearchDto.getSearchQuery();
+        Pageable pageable = PageRequest.of(page.orElse(0),6);
+        Page<Item> mainPageItems = itemService.getMainItems(searchQuery,pageable);
+        return toDto(mainPageItems);
+    }
+
+    private Page<MainItemDto> toDto(Page<Item> mainPageItems){
+
+        return mainPageItems.map(item -> MainItemDto.builder()
+                .itemId(item.getId())
+                .itemName(item.getItemName())
+                .itemDetail(item.getItemDetail())
+                .imageUrl(itemImageService.getRepImage(item.getId()).getImageUrl())
+                .price(item.getPrice())
+                .build());
+    }
+
+
+}

--- a/src/main/java/com/shop/projectlion/web/orderhist/controller/OrderHistController.java
+++ b/src/main/java/com/shop/projectlion/web/orderhist/controller/OrderHistController.java
@@ -1,0 +1,62 @@
+package com.shop.projectlion.web.orderhist.controller;
+
+import com.shop.projectlion.domain.order.constant.OrderStatus;
+import com.shop.projectlion.web.orderhist.dto.OrderHistDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.security.Principal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/orderhist")
+public class OrderHistController {
+
+    @GetMapping
+    public String orderHist(Optional<Integer> page, Model model, Principal principal) {
+        Pageable pageable = PageRequest.of(page.isPresent() ? page.get() : 0, 6);
+
+        // 주문 정보
+        List<OrderHistDto> orderHistDtos = new ArrayList<>();
+        OrderHistDto orderHistDto = OrderHistDto.builder()
+                .orderId(1L)
+                .orderTime(LocalDateTime.now())
+                .orderStatus(OrderStatus.ORDER)
+                .totalPrice(13000)
+                .totalDeliveryFee(3000)
+                .build();
+        orderHistDtos.add(orderHistDto);
+
+        // 주문 상품 정보
+        List<OrderHistDto.OrderItemHistDto> orderItemHistDtos = new ArrayList<>();
+        for(int i=1;i<2;i++) {
+            OrderHistDto.OrderItemHistDto orderItemHistDto = OrderHistDto.OrderItemHistDto.builder()
+                    .imageUrl("/images/2a87e656-79f0-405f-98da-aee2be5ba333.jpg")
+                    .orderPrice(5000)
+                    .count(1)
+                    .itemName("청바지" + i)
+                    .build();
+            orderItemHistDtos.add(orderItemHistDto);
+        }
+        orderHistDto.setOrderItemHistDtos(orderItemHistDtos);
+
+
+        Page<OrderHistDto> pageOrderHistDtos = new PageImpl<>(orderHistDtos, pageable, 30);
+        model.addAttribute("orders", pageOrderHistDtos);
+        model.addAttribute("page", pageable.getPageNumber());
+        model.addAttribute("maxPage", 5); // 메인페이지에 노출되는 최대 페이지 갯수
+        return "orderhist/orderhist";
+    }
+
+}

--- a/src/main/java/com/shop/projectlion/web/orderhist/controller/OrderHistController.java
+++ b/src/main/java/com/shop/projectlion/web/orderhist/controller/OrderHistController.java
@@ -1,21 +1,22 @@
 package com.shop.projectlion.web.orderhist.controller;
 
-import com.shop.projectlion.domain.order.constant.OrderStatus;
+import com.shop.projectlion.global.error.exception.BusinessException;
 import com.shop.projectlion.web.orderhist.dto.OrderHistDto;
+import com.shop.projectlion.web.orderhist.service.OrderHistService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.security.Principal;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 @Controller
@@ -23,40 +24,29 @@ import java.util.Optional;
 @RequestMapping("/orderhist")
 public class OrderHistController {
 
+    private final OrderHistService orderHistService;
+
     @GetMapping
     public String orderHist(Optional<Integer> page, Model model, Principal principal) {
+
         Pageable pageable = PageRequest.of(page.isPresent() ? page.get() : 0, 6);
-
-        // 주문 정보
-        List<OrderHistDto> orderHistDtos = new ArrayList<>();
-        OrderHistDto orderHistDto = OrderHistDto.builder()
-                .orderId(1L)
-                .orderTime(LocalDateTime.now())
-                .orderStatus(OrderStatus.ORDER)
-                .totalPrice(13000)
-                .totalDeliveryFee(3000)
-                .build();
-        orderHistDtos.add(orderHistDto);
-
-        // 주문 상품 정보
-        List<OrderHistDto.OrderItemHistDto> orderItemHistDtos = new ArrayList<>();
-        for(int i=1;i<2;i++) {
-            OrderHistDto.OrderItemHistDto orderItemHistDto = OrderHistDto.OrderItemHistDto.builder()
-                    .imageUrl("/images/2a87e656-79f0-405f-98da-aee2be5ba333.jpg")
-                    .orderPrice(5000)
-                    .count(1)
-                    .itemName("청바지" + i)
-                    .build();
-            orderItemHistDtos.add(orderItemHistDto);
-        }
-        orderHistDto.setOrderItemHistDtos(orderItemHistDtos);
-
-
-        Page<OrderHistDto> pageOrderHistDtos = new PageImpl<>(orderHistDtos, pageable, 30);
+        Page<OrderHistDto> pageOrderHistDtos = orderHistService.getOrderHistDtos(principal.getName(), pageable);
         model.addAttribute("orders", pageOrderHistDtos);
         model.addAttribute("page", pageable.getPageNumber());
         model.addAttribute("maxPage", 5); // 메인페이지에 노출되는 최대 페이지 갯수
         return "orderhist/orderhist";
+    }
+
+    @PostMapping("/{orderId}/cancel")
+    public ResponseEntity<String> cancelOrder(@PathVariable("orderId") Long orderId, Principal principal) {
+
+        try {
+            orderHistService.cancelOrder(orderId, principal.getName());
+        } catch (BusinessException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.FORBIDDEN);
+        }
+
+        return ResponseEntity.ok("order cancel success");
     }
 
 }

--- a/src/main/java/com/shop/projectlion/web/orderhist/dto/OrderHistDto.java
+++ b/src/main/java/com/shop/projectlion/web/orderhist/dto/OrderHistDto.java
@@ -1,0 +1,33 @@
+package com.shop.projectlion.web.orderhist.dto;
+
+import com.shop.projectlion.domain.order.constant.OrderStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class OrderHistDto {
+
+    private Long orderId;
+    private LocalDateTime orderTime;
+    private OrderStatus orderStatus;
+    private int totalPrice;
+    private int totalDeliveryFee;
+
+    private List<OrderItemHistDto> orderItemHistDtos;
+
+    @Getter @Setter
+    @Builder
+    public static class OrderItemHistDto {
+        private String itemName;
+        private int count;
+        private int orderPrice;
+        private String imageUrl;
+    }
+
+}

--- a/src/main/java/com/shop/projectlion/web/orderhist/dto/OrderHistDto.java
+++ b/src/main/java/com/shop/projectlion/web/orderhist/dto/OrderHistDto.java
@@ -1,6 +1,9 @@
 package com.shop.projectlion.web.orderhist.dto;
 
+import com.shop.projectlion.domain.itemImage.entity.ItemImage;
 import com.shop.projectlion.domain.order.constant.OrderStatus;
+import com.shop.projectlion.domain.order.entity.Order;
+import com.shop.projectlion.domain.orderItem.entity.OrderItem;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -21,6 +24,16 @@ public class OrderHistDto {
 
     private List<OrderItemHistDto> orderItemHistDtos;
 
+    public static OrderHistDto of(Order order) {
+        return OrderHistDto.builder()
+                .orderId(order.getId())
+                .orderTime(order.getOrderTime())
+                .orderStatus(order.getOrderStatus())
+                .totalPrice(order.getTotalPrice())
+                .totalDeliveryFee(order.getTotalDeliveryFee())
+                .build();
+    }
+
     @Getter @Setter
     @Builder
     public static class OrderItemHistDto {
@@ -28,6 +41,15 @@ public class OrderHistDto {
         private int count;
         private int orderPrice;
         private String imageUrl;
+
+        public static OrderItemHistDto of(OrderItem orderItem, ItemImage itemImage) {
+            return OrderItemHistDto.builder()
+                    .imageUrl(itemImage.getImageUrl())
+                    .orderPrice(orderItem.getOrderPrice())
+                    .count(orderItem.getCount())
+                    .itemName(orderItem.getItem().getItemName())
+                    .build();
+        }
     }
 
 }

--- a/src/main/java/com/shop/projectlion/web/orderhist/service/OrderHistService.java
+++ b/src/main/java/com/shop/projectlion/web/orderhist/service/OrderHistService.java
@@ -1,0 +1,72 @@
+package com.shop.projectlion.web.orderhist.service;
+
+import com.shop.projectlion.domain.itemImage.entity.ItemImage;
+import com.shop.projectlion.domain.itemImage.service.ItemImageService;
+import com.shop.projectlion.domain.order.entity.Order;
+import com.shop.projectlion.domain.order.service.OrderService;
+import com.shop.projectlion.domain.orderItem.entity.OrderItem;
+import com.shop.projectlion.global.error.exception.BusinessException;
+import com.shop.projectlion.global.error.exception.ErrorCode;
+import com.shop.projectlion.web.orderhist.dto.OrderHistDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrderHistService {
+
+    private final OrderService orderService;
+    private final ItemImageService itemImageService;
+
+    public PageImpl<OrderHistDto> getOrderHistDtos(String email, Pageable pageable) {
+
+        // 1. 회원 및 주문 데이터 조회
+        Page<Order> orders = orderService.findOrderWithMember(email, pageable);
+
+        // 2. 주문 데이터 dto 변환
+        List<OrderHistDto> orderHistDtos = new ArrayList<>();
+        for (Order order : orders) {
+
+            // 3. 주문 정보 dto 생성
+            OrderHistDto orderHistDto = OrderHistDto.of(order);
+
+            // 4. 주문 상품 dto 리스트 생성
+            List<OrderHistDto.OrderItemHistDto> orderItemHistDto = getOrderItemHistDtos(order);
+            orderHistDto.setOrderItemHistDtos(orderItemHistDto);
+
+            orderHistDtos.add(orderHistDto);
+        }
+
+        return new PageImpl<>(orderHistDtos, pageable, orders.getTotalElements());
+    }
+
+    private List<OrderHistDto.OrderItemHistDto> getOrderItemHistDtos(Order order) {
+        List<OrderItem> orderItems = order.getOrderItems();
+        List<OrderHistDto.OrderItemHistDto> orderItemHistDto = orderItems.stream().map(orderItem -> {
+            ItemImage itemImage = itemImageService.findByItemAndIsRepImage(orderItem.getItem(), true);
+            return OrderHistDto.OrderItemHistDto.of(orderItem, itemImage);
+        }).collect(Collectors.toList());
+        return orderItemHistDto;
+    }
+
+    @Transactional
+    public void cancelOrder(Long orderId, String email) {
+        Order order = orderService.findByOrderIdWithMemberAndOrderItemsAndItem(orderId);
+
+        if(!order.getMember().getEmail().equals(email)) {
+            throw new BusinessException(ErrorCode.NOT_MEMBER_ORDER.getMessage());
+        }
+
+        order.cancelOrder();
+    }
+
+}

--- a/src/main/resources/templates/itemdtl/itemdtl.html
+++ b/src/main/resources/templates/itemdtl/itemdtl.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/shoplayout}">
+
+<head>
+    <meta name="_csrf" th:content="${_csrf.token}"/>
+    <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
+</head>
+
+<!-- 사용자 CSS 추가 -->
+<th:block layout:fragment="css">
+    <style>
+        .mgb-15{
+            margin-bottom:15px;
+        }
+        .mgt-30{
+            margin-top:30px;
+        }
+        .mgt-50{
+            margin-top:50px;
+        }
+        .repImgDiv{
+            margin-right:15px;
+            height:auto;
+            width:50%;
+        }
+        .repImg{
+            width:100%;
+            height:400px;
+        }
+        .wd50{
+            height:auto;
+            width:50%;
+        }
+        .jumbotron {
+            padding: 2rem 1rem;
+            margin-bottom: 2rem;
+            background-color: #e9ecef;
+            border-radius: .3rem;
+            overflow: auto;
+        }
+    </style>
+</th:block>
+
+<div layout:fragment="content" style="margin-left:25%;margin-right:25%">
+
+    <input type="hidden" id="itemId" th:value="${item.itemId}">
+
+    <div class="d-flex">
+        <div class="repImgDiv">
+            <img th:src="${item.itemImageDtos[0].imageUrl}" class = "rounded repImg" th:alt="${item.itemName}">
+        </div>
+        <div class="wd50">
+
+            <span th:if="${item.itemSellStatus == T(com.shop.projectlion.domain.item.constant.ItemSellStatus).SELL}" class="badge bg-primary mgb-15">판매중</span>
+            <span th:unless="${item.itemSellStatus == T(com.shop.projectlion.domain.item.constant.ItemSellStatus).SELL}" class="badge btn-danger mgb-15">품절</span>
+            <div class="h4" th:text="${item.itemName}"></div>
+            <hr class="my-4">
+
+            <div class="text-right">
+                <div class="h4 text-danger text-left">
+                    <input type="hidden" th:field="${item.price}">
+                    <span th:text="|상품 가격 : ${item.price}|"></span>원
+                </div>
+                <div class="h4 text-danger text-left">
+                    <input type="hidden" th:field="${item.deliveryFee}">
+                    <span th:text="|배송비 : ${item.deliveryFee}|"></span>원
+                </div>
+                <div class="input-group w-50">
+                    <div class="input-group-prepend">
+                        <span class="input-group-text">수량</span>
+                    </div>
+                    <input type="number" name="count" id="count" class="form-control" value="1" min="1">
+                </div>
+            </div>
+            <hr class="my-4">
+
+            <div class="text-end mgt-50">
+                <h5>결제 금액</h5>
+                <h3 name="totalPrice" id="totalPrice" class="font-weight-bold"></h3>
+            </div>
+            <div th:if="${item.itemSellStatus == T(com.shop.projectlion.domain.item.constant.ItemSellStatus).SELL}" class="text-end">
+                <button type="button" class="btn btn-primary btn-lg" onclick="order()">주문하기</button>
+            </div>
+            <div th:unless="${item.itemSellStatus == T(com.shop.projectlion.domain.item.constant.ItemSellStatus).SELL}" class="text-end">
+                <button type="button" class="btn btn-danger btn-lg">품절</button>
+            </div>
+        </div>
+    </div>
+
+    <div class="jumbotron jumbotron-fluid mgt-30 jb">
+        <p class="h3">상품 상세 설명</p>
+        <hr class="my-4">
+        <th:block th:text="${item.itemDetail}"></th:block>
+    </div>
+
+    <div th:each="itemImageDto : ${item.itemImageDtos}" class="text-center">
+        <img th:if="${not #strings.isEmpty(itemImageDto.imageUrl)}" th:src="${itemImageDto.imageUrl}" class="rounded mgb-15" width="800">
+    </div>
+
+</div>
+
+<!-- 사용자 스크립트 추가 -->
+<th:block layout:fragment="script">
+    <script th:inline="javascript">
+        $(document).ready(function(){
+
+            calculateToalPrice();
+
+            $("#count").change( function(){
+                calculateToalPrice();
+            });
+        });
+
+        function calculateToalPrice(){
+            var count = $("#count").val();
+            var price = $("#price").val();
+            var deliveryFee = $("#deliveryFee").val();
+            var totalPrice = price*count + parseInt(deliveryFee);
+            $("#totalPrice").html(totalPrice + '원');
+        }
+
+        function order(){
+            var token = $("meta[name='_csrf']").attr("content");
+            var header = $("meta[name='_csrf_header']").attr("content");
+
+            var url = "/itemdtl/order";
+            var paramData = {
+                itemId : $("#itemId").val(),
+                count : $("#count").val()
+            };
+
+            var param = JSON.stringify(paramData);
+
+            $.ajax({
+                url      : url,
+                type     : "POST",
+                contentType : "application/json",
+                data     : param,
+                beforeSend : function(xhr){
+                    /* 데이터를 전송하기 전에 헤더에 csrf값을 설정 */
+                    xhr.setRequestHeader(header, token);
+                },
+                success  : function(result, status){
+                    alert("주문이 완료 되었습니다.");
+                    location.href='/orderhist';
+                },
+                error : function(jqXHR, status, error){
+                    if(jqXHR.status == '401'){
+                        alert('로그인 후 이용해주세요');
+                        location.href='/login';
+                    } else{
+                        alert(jqXHR.responseText);
+                    }
+                }
+            });
+        }
+    </script>
+</th:block>
+
+</html>

--- a/src/main/resources/templates/main/mainpage.html
+++ b/src/main/resources/templates/main/mainpage.html
@@ -1,11 +1,91 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:layout=http://www.ultraq.net.nz/thymeleaf/layout
       layout:decorate="~{layouts/shoplayout}">
 
-    <div layout:fragment="content" class="content">
-        <div class="text-center mt-3">
-            본문 영역 입니다.
+<!-- 사용자 CSS 추가 -->
+<th:block layout:fragment="css">
+    <style>
+        .carousel-inner > .item {
+            height: 350px;
+        }
+        .margin{
+            margin-bottom:30px;
+        }
+        .banner{
+            height: 300px;
+        }
+        .card-text{
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow: hidden;
+        }
+        a:hover{
+            text-decoration:none;
+        }
+        .center{
+            text-align:center;
+        }
+        .banner{
+            position: absolute; top:0; left: 0;
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+</th:block>
+
+<div layout:fragment="content" class="container center_div w-75 mt-4">
+
+    <div id="carouselControls" class="carousel slide margin" data-ride="carousel">
+        <div class="carousel-inner">
+            <div class="carousel-item active item">
+                <img class="d-block w-100 banner" src="https://user-images.githubusercontent.com/13268420/112147492-1ab76200-8c20-11eb-8649-3d2f282c3c02.png" alt="First slide">
+            </div>
         </div>
     </div>
+
+    <input type="hidden" name="searchQuery" th:value="${itemSearchDto.searchQuery}">
+    <div th:if="${not #strings.isEmpty(itemSearchDto.searchQuery)}" class="center mb-3">
+        <p class="h3 font-weight-bold" th:text="${itemSearchDto.searchQuery} + ' 검색 결과'"></p>
+    </div>
+
+    <div class="row">
+        <th:block th:each="item, status: ${items.getContent()}">
+            <div class="col-md-4 margin">
+                <div class="card">
+                    <a th:href="'/itemdtl/' +${item.itemId}" class="text-dark">
+                        <img th:src="${item.imageUrl}" class="card-img-top" th:alt="${item.itemName}" height="400">
+                        <div class="card-body">
+                            <h4 class="card-title">[[${item.itemName}]]</h4>
+                            <p class="card-text">[[${item.itemDetail}]]</p>
+                            <h3 class="card-title text-danger">[[${item.price}]]원</h3>
+                        </div>
+                    </a>
+                </div>
+            </div>
+        </th:block>
+    </div>
+
+    <div th:with="start=${(items.number/maxPage)*maxPage + 1}, end=(${(items.totalPages == 0) ? 1 : (start + (maxPage - 1) < items.totalPages ? start + (maxPage - 1) : items.totalPages)})" >
+        <ul class="pagination justify-content-center">
+
+            <li class="page-item" th:classappend="${items.number eq 0}?'disabled':''">
+                <a th:href="@{/(searchQuery=${itemSearchDto.searchQuery}, page=${items.number-1})}" aria-label='Previous' class="page-link">
+                    <span aria-hidden='true'>Previous</span>
+                </a>
+            </li>
+
+            <li class="page-item" th:each="page: ${#numbers.sequence(start, end)}" th:classappend="${items.number eq page-1}?'active':''">
+                <a th:href="@{/(searchQuery=${itemSearchDto.searchQuery}, page=${page-1})}" th:inline="text" class="page-link">[[${page}]]</a>
+            </li>
+
+            <li class="page-item" th:classappend="${items.number+1 ge items.totalPages}?'disabled':''">
+                <a th:href="@{/(searchQuery=${itemSearchDto.searchQuery}, page=${items.number+1})}" aria-label='Next' class="page-link">
+                    <span aria-hidden='true'>Next</span>
+                </a>
+            </li>
+
+        </ul>
+    </div>
+</div>
 </html>

--- a/src/main/resources/templates/orderhist/orderhist.html
+++ b/src/main/resources/templates/orderhist/orderhist.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/shoplayout}">
+
+<head>
+    <meta name="_csrf" th:content="${_csrf.token}"/>
+    <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
+</head>
+
+<!-- 사용자 CSS 추가 -->
+<th:block layout:fragment="css">
+    <style>
+        .content-mg{
+            margin-left:30%;
+            margin-right:30%;
+            margin-top:2%;
+            margin-bottom:100px;
+        }
+        .repImgDiv{
+            margin-right:15px;
+            margin-left:15px;
+            height:auto;
+        }
+        .repImg{
+            height:100px;
+            width:100px;
+        }
+        .card{
+            width:750px;
+            height:100%;
+            padding:30px;
+            margin-bottom:20px;
+        }
+        .fs18{
+            font-size:18px
+        }
+        .fs24{
+            font-size:24px
+        }
+    </style>
+</th:block>
+
+<div layout:fragment="content" class="content-mg">
+
+    <h2 class="mb-4">
+        구매 이력
+    </h2>
+
+    <div th:each="order : ${orders.getContent()}">
+
+        <div class="d-flex mb-3 align-self-center">
+            <h4 th:text="|${#temporals.format(order.orderTime, 'yyyy-MM-dd HH:mm:ss')} 주문|"></h4>
+            <div class="ms-3">
+                <th:block th:if="${order.orderStatus == T(com.shop.projectlion.domain.order.constant.OrderStatus).ORDER}">
+                    <button type="button" class="btn btn-outline-secondary" th:value="${order.orderId}" onclick="cancelOrder(this.value)">주문취소</button>
+                </th:block>
+                <th:block th:unless="${order.orderStatus == T(com.shop.projectlion.domain.order.constant.OrderStatus).ORDER}">
+                    <h4>(취소 완료)</h4>
+                </th:block>
+            </div>
+        </div>
+        <div class="card d-flex">
+            <div th:each="orderItem : ${order.orderItemHistDtos}" class="d-flex mb-3">
+                <div class="repImgDiv">
+                    <img th:src="${orderItem.imageUrl}" class = "rounded repImg" th:alt="${orderItem.itemName}">
+                </div>
+                <div class="align-self-center w-75">
+                    <span th:text="${orderItem.itemName}" class="fs24 font-weight-bold"></span>
+                    <div class="fs18 font-weight-light">
+                        <span th:text="|${#numbers.formatInteger(orderItem.orderPrice, 0, 'COMMA')} 원, |"></span>
+                        <span th:text="|${orderItem.count} 개|"></span>
+                    </div>
+                </div>
+            </div>
+            <div>
+                <div class="fs18 font-weight-bold">
+                    <span th:text="|배송비 : ${#numbers.formatInteger(order.totalDeliveryFee, 0, 'COMMA')} 원, |"></span>
+                    <span th:text="|총 가격 : ${#numbers.formatInteger(order.totalPrice, 0, 'COMMA')} 원|"></span>
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+    <div th:with="start=${(orders.number/maxPage)*maxPage + 1}, end=(${(orders.totalPages == 0) ? 1 : (start + (maxPage - 1) < orders.totalPages ? start + (maxPage - 1) : orders.totalPages)})" >
+        <ul class="pagination justify-content-center">
+
+            <li class="page-item" th:classappend="${orders.number eq 0}?'disabled':''">
+                <a th:href="@{/orderhist(page=${orders.number}-1)}" aria-label='Previous' class="page-link">
+                    <span aria-hidden='true'>Previous</span>
+                </a>
+            </li>
+
+            <li class="page-item" th:each="page: ${#numbers.sequence(start, end)}" th:classappend="${orders.number eq page-1}?'active':''">
+                <a th:href="@{/orderhist(page=${page-1})}" th:inline="text" class="page-link">[[${page}]]</a>
+            </li>
+
+            <li class="page-item" th:classappend="${orders.number+1 ge orders.totalPages}?'disabled':''">
+                <a th:href="@{/orderhist(page=${orders.number+1})}" aria-label='Next' class="page-link">
+                    <span aria-hidden='true'>Next</span>
+                </a>
+            </li>
+
+        </ul>
+    </div>
+
+    <!-- 사용자 스크립트 추가 -->
+    <th:block layout:fragment="script">
+
+        <script th:inline="javascript">
+            function cancelOrder(orderId) {
+                var token = $("meta[name='_csrf']").attr("content");
+                var header = $("meta[name='_csrf_header']").attr("content");
+
+                var url = "/orderhist/" + orderId + "/cancel";
+                var paramData = {
+                    orderId : orderId,
+                };
+
+                var param = JSON.stringify(paramData);
+
+                $.ajax({
+                    url      : url,
+                    type     : "POST",
+                    contentType : "application/json",
+                    data     : param,
+                    beforeSend : function(xhr){
+                        /* 데이터를 전송하기 전에 헤더에 csrf값을 설정 */
+                        xhr.setRequestHeader(header, token);
+                    },
+                    success  : function(result, status){
+                        alert("주문이 취소 되었습니다.");
+                        location.href='/orderhist?page=' + [[${page}]];
+                    },
+                    error : function(jqXHR, status, error){
+                        if(jqXHR.status == '401'){
+                            alert('로그인 후 이용해주세요');
+                            location.href='/login';
+                        } else{
+                            alert(jqXHR.responseText);
+                        }
+                    }
+                });
+            }
+        </script>
+
+    </th:block>
+
+</div>
+
+</html>


### PR DESCRIPTION
메인페이지 상품 조회 구현

- 메인페이지에 한 페이지 당 상품이 6개씩 노출되도록 구현
- 품절인 상품은 미노출 처리
- 오른쪽 상단 검색창에서 상품명/키워드로 검색 시 해당 키워드를 포함하고 있는 상품 리스트만 조회
- 상품상세 or 상품명 조회

상품 상세 페이지 조회 구현

- 대표 이미지(첫번째 이미지) 왼쪽 상단 노출
- 상품 판매 상태(판매중/품절) 조회
- 상품명 / 상품 가격 / 배송비 / 상품 상세 설명 조회
- 상품 상세 설명 하단에는 해당 상품의 이미지 나열
- 품절 상태일 경우 주문하기 버튼 미노출

주문 하기 구현

- 상품 상세 페이지에서 주문하기 버튼 클릭 시 주문 로직 수행 (ajax를 사용한 비동기 처리)
- 주문 성공 시 상품 주문 개수만큼 상품의 재고 차감
- 주문 성공 후 주문 이력 페이지 이동
- 주문 상태(OrderStatus)는 ORDER로 저장
- 주문 수량이 상품의 재고보다 많을 경우 주문 실패 처리

주문 이력 조회(추가구현)

- 현재 회원의 주문 이력 조회
- 한 페이지당 6개씩 조회하도록 구현

주문 취소(추가구현)

- 주문 이력 페이지에서 주문 취소버튼 클릭 시 주문 취소 로직 수행
- 주문 취소 시 주문 개수만큼 상품의 재고를 증가
- 주문 상태(OrderStatus)는 CANCEL로 저장